### PR TITLE
Composer requirements and avoid warnings

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -302,10 +302,12 @@ class Data extends AbstractHelperAlias
                 }
                 $catPaths = array_reverse(explode(',', $cat->getPathInStore()));
                 foreach ($catPaths as $index => $catId) {
-                    if ($index == (count($catPaths) - 1)) {
-                        $categoryPath .= $categoriesName[$catId];
-                    } else {
-                        $categoryPath .= $categoriesName[$catId] . ' > ';
+                    if (isset($categoriesName[$catId])) {
+                        if ($index == (count($catPaths) - 1)) {
+                            $categoryPath .= $categoriesName[$catId];
+                        } else {
+                            $categoryPath .= $categoriesName[$catId] . ' > ';
+                        }
                     }
                 }
             }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
   "name": "magenest/module-product-feed",
   "description": "Product Feed module for Magento 2 by Magenest",
   "require": {
-    "magenest/core": "*"
+    "magenest/core": "*",
+    "liquid/liquid": "*"
   },
   "type": "magento2-module",
   "version": "1.0.0",


### PR DESCRIPTION
Hi,

Here is a pull request with 2 fixes to avoid errors when generating the feed:

* In composer.json we add the liquid/liquid dependency (which is not installed by default in Magento)
* We also add a isset check to avoid warning issues when no category mapping is done

Thanks for this great module!